### PR TITLE
Use c99 instead of gcc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-CC=gcc
+CC=c99
 CFLAGS=-Wall -pedantic -g
 LDFLAGS=-ljansson -lcurl
 


### PR DESCRIPTION
This should be a reasonably portable way to compile to c99 standard
across platforms.
