### PR TITLE
Makefile cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,18 +1,17 @@
-CC=c99
-CFLAGS=-Wall -pedantic -g
-LDFLAGS=-ljansson -lcurl
+CFLAGS = -std=c99 -Wall -pedantic -g
+LDFLAGS = -ljansson -lcurl
 
-OBJECTS=sea.o request.o account.o
+OBJECTS = account.o \
+	  request.o \
+	  sea.o
 
 sea: $(OBJECTS)
-	    $(CC) $(CFLAGS) $(OBJECTS) -o sea $(LDFLAGS)
+	$(CC) $(CFLAGS) $(OBJECTS) $(LDFLAGS) -o $@
 
-all:sea
+all: sea
 
-.PHONY: clean
-	clean:
-	    rm -f *~ *.o client
+clean:
+	$(RM) *.o
+	$(RM) sea
 
-
-# all:
-# 	gcc -I . -o sea -ljansson drosh.c account.c
+.PHONY: all clean


### PR DESCRIPTION
- remove `CC=c99`, c99 isn't available on OSX. I think removing `CC` and
  passing `-std=c99` will give us the same result on most systems.
- fix `clean`
- fix indentation
- remove some early-stage cruft (drosh.c, *~, client)
