### PR TITLE
ssh key retrieval

### DIFF
--- a/src/account.c
+++ b/src/account.c
@@ -26,6 +26,138 @@ void account_free(struct account *a)
 	a = NULL;
 }
 
+// account_ssh_keys retrieves a users ssh keys.
+//
+// On success, a list of ssh keys is returned.
+// It is the responsibility of the caller to free each key with
+// a call to account_ssh_key_free().
+//
+// On failure NULL is returned.
+struct ssh_keys *
+account_ssh_keys()
+{
+	struct ssh_keys *keys = NULL;
+	char url[URL_SIZE];
+	char *endpoint = "/account/keys";
+	char *response = NULL;
+
+	strncpy(url, URL_BASE, URL_SIZE - strlen(endpoint));
+	strncat(url, endpoint, strlen(endpoint));
+
+	response = request(url);
+	if(!response)
+		return NULL;
+
+	json_t *root;
+	json_error_t error;
+	root = json_loads(response, 0, &error);
+	free(response);
+	response = NULL;
+
+	if(!root) {
+		fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
+		return NULL;
+	}
+
+	if(!json_is_object(root)) {
+		fprintf(stderr, "error: root is not an object\n");
+		goto error;
+	}
+
+	json_t *container;
+	container = json_object_get(root, "ssh_keys");
+	if(!json_is_array(container)) {
+		fprintf(stderr, "error: ssh_keys is not an array\n");
+		goto error;
+	}
+
+	keys = malloc(sizeof(struct ssh_keys));
+	if(keys == NULL)
+		goto error;
+	keys->count = json_array_size(container);
+	keys->keys = malloc(sizeof(struct ssh_key) * keys->count);
+	if(keys->keys == NULL)
+		goto error;
+
+	for(int i = 0; i < keys->count; i++) {
+		keys->keys[i] = malloc(sizeof(struct ssh_key));
+		if(keys->keys[i] == NULL)
+			goto error;
+
+		json_t *elem, *id, *name, *fingerprint, *public_key;
+
+		elem = json_array_get(container, i);
+		if(!json_is_object(elem)) {
+			fprintf(stderr, "error: ssh key data %d is not an object\n", i + 1);
+			goto error;
+		}
+
+		id = json_object_get(elem, "id");
+		if(!json_is_integer(id)) {
+			fprintf(stderr, "error: ssh key name is not a string\n");
+			goto error;
+		}
+
+		name = json_object_get(elem, "name");
+		if(!json_is_string(name)) {
+			fprintf(stderr, "error: ssh key name is not a string\n");
+			goto error;
+		}
+
+		fingerprint = json_object_get(elem, "fingerprint");
+		if(!json_is_string(name)) {
+			fprintf(stderr, "error: ssh key fingerprint is not a string\n");
+			goto error;
+		}
+
+		public_key = json_object_get(elem, "public_key");
+		if(!json_is_string(name)) {
+			fprintf(stderr, "error: ssh public_key is not a string\n");
+			goto error;
+		}
+
+		const char *tmp_n  = json_string_value(name);
+		const char *tmp_fp = json_string_value(fingerprint);
+		const char *tmp_pk = json_string_value(public_key);
+
+		keys->keys[i]->id = (int)json_integer_value(id);
+		keys->keys[i]->name = malloc(sizeof(char) * strlen(tmp_n) + 1);
+		keys->keys[i]->fingerprint = malloc(sizeof(char) * strlen(tmp_fp) + 1);
+		keys->keys[i]->public_key = malloc(sizeof(char) * strlen(tmp_pk) + 1);
+
+		strncpy(keys->keys[i]->name, tmp_n, strlen(tmp_n) + 1);
+		strncpy(keys->keys[i]->fingerprint, tmp_fp, strlen(tmp_fp) + 1);
+		strncpy(keys->keys[i]->public_key, tmp_pk, strlen(tmp_pk) + 1);
+	}
+
+	json_decref(root);
+	return keys;
+error:
+	ssh_keys_free(keys);
+	json_decref(root);
+
+	return NULL;
+}
+
+void ssh_key_free(struct ssh_key *key)
+{
+	free(key->name);
+	free(key->fingerprint);
+	free(key->public_key);
+	key = NULL;
+}
+
+void ssh_keys_free(struct ssh_keys *keys)
+{
+	for(int i = 0; i< keys->count; i++)
+		if(keys->keys[i])
+			ssh_key_free(keys->keys[i]);
+	if(keys->keys)
+		free(keys->keys);
+	if(keys)
+		free(keys);
+}
+
 int account_get(struct account *a)
 {
 	if(a == NULL)

--- a/src/account.h
+++ b/src/account.h
@@ -12,8 +12,27 @@ struct account
 	char *status_message;
 };
 
+struct ssh_keys
+{
+	int count;
+	struct ssh_key **keys;
+};
+
+struct ssh_key
+{
+	int id;
+	char *name;
+	char *fingerprint;
+	char *public_key;
+};
+
 struct account *account_new(void);
 void account_free(struct account *a);
 int account_get(struct account *a);
+struct ssh_keys *account_ssh_keys(void);
+
+struct ssh_key *ssh_key_new(void);
+void ssh_key_free(struct ssh_key *key);
+void ssh_keys_free(struct ssh_keys *keys);
 
 #endif /* _SEA_ACCOUNT_H */

--- a/src/sea.c
+++ b/src/sea.c
@@ -28,8 +28,10 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if(!account_get(a))
+	if(!account_get(a)) {
+		account_free(a);
 		return EXIT_FAILURE;
+	}
 
 	printf("Email: %s (verified: %s)\nStatus: %s\nStatus Message: %s\nUUID: %s\nDroplet Limit: %d\nFloating IP Limit: %d\n",
 			a->email,
@@ -39,8 +41,20 @@ int main(int argc, char *argv[])
 			a->uuid,
 			a->droplet_limit,
 			a->floating_ip_limit);
-
 	account_free(a);
+
+	struct ssh_keys *keys = NULL;
+	keys = account_ssh_keys();
+
+	printf("SSH Keys (%d):\n", keys->count);
+	for(int i = 0; i < keys->count; i++) {
+		printf("\tID: %d\n\tName: %s\n\tFingerprint: %s\n\tPublic Key: %s\n",
+				keys->keys[i]->id,
+				keys->keys[i]->name,
+				keys->keys[i]->fingerprint,
+				keys->keys[i]->public_key);
+	}
+	ssh_keys_free(keys);
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This adds support for pulling down account ssh keys. I've bounced back and forth over the API, settling on the return type of `struct ssh_keys *`. This allows for both error checking and clear memory management responsibilities. In the future we may want to abstract the `ssh_keys` type to a more generic storage container or linked list. 
