### PR TITLE
Add droplet support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ CC=c99
 CFLAGS=-Wall -pedantic -g
 LDFLAGS=-ljansson -lcurl
 
-OBJECTS=sea.o request.o account.o
+OBJECTS=sea.o request.o account.o droplet.o
 
 sea: $(OBJECTS)
 	    $(CC) $(CFLAGS) $(OBJECTS) -o sea $(LDFLAGS)

--- a/src/droplet.c
+++ b/src/droplet.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <jansson.h>
+
+#include "sea.h"
+#include "droplet.h"
+#include "request.h"
+
+struct droplet *droplet_new()
+{
+	struct droplet *d = NULL;
+	d = calloc(1, sizeof(struct droplet));
+
+	return d;
+}
+
+void droplet_free(struct droplet *d)
+{
+	free(d->name);
+	free(d);
+	d = NULL;
+}
+
+int droplet_get_by_id(struct droplet *d, int id)
+{
+	if(d == NULL)
+		return 0;
+
+	int ret = 1;
+	char url[URL_SIZE];
+	char *endpoint = "%s/droplets/%d";
+	char *response = NULL;
+
+	snprintf(url, URL_SIZE, endpoint, URL_BASE, id);
+
+	response = request(url);
+	if(!response)
+		return 0;
+
+	json_t *root;
+	json_error_t error;
+	root = json_loads(response, 0, &error);
+	free(response);
+	response = NULL;
+
+	if(!root)
+	{
+		fprintf(stderr, "error: on line %d: %s\n", error.line, error.text);
+		return 0;
+	}
+
+	if(!json_is_object(root))
+	{
+		fprintf(stderr, "error: root is not an object\n");
+		ret = 0;
+		goto finish;
+	}
+
+	json_t *data,
+	       *droplet_id,
+	       *name,
+	       *memory,
+	       *vcpus,
+	       *disk,
+	       *locked;
+//	       *created_at,
+//	       *status,
+//	       *backup_id,
+//	       *snapshot_ids,
+//	       *features,
+//	       *size_slug,
+//	       *tags,
+//	       *volume_ids;
+
+	data = json_object_get(root, "droplet");
+	if(!json_is_object(data))
+	{
+		fprintf(stderr, "error: account data is not an object\n");
+		ret = 0;
+		goto finish;
+	}
+
+	droplet_id = json_object_get(data, "id");
+	if(!json_is_integer(droplet_id))
+	{
+		fprintf(stderr, "error: id is not a number\n");
+		ret = 0;
+		goto finish;
+	}
+
+	name = json_object_get(data, "name");
+	if(!json_is_string(name))
+	{
+		fprintf(stderr, "error: name is not an string\n");
+		ret = 0;
+		goto finish;
+	}
+
+	memory = json_object_get(data, "memory");
+	if(!json_is_integer(memory))
+	{
+		fprintf(stderr, "error: memory is not a number\n");
+		ret = 0;
+		goto finish;
+	}
+
+	vcpus = json_object_get(data, "vcpus");
+	if(!json_is_integer(vcpus))
+	{
+		fprintf(stderr, "error: vcpus is not an integer\n");
+		ret = 0;
+		goto finish;
+	}
+
+	disk = json_object_get(data, "disk");
+	if(!json_is_integer(disk))
+	{
+		fprintf(stderr, "error: disk is not a number\n");
+		ret = 0;
+		goto finish;
+	}
+
+	locked = json_object_get(data, "locked");
+	if(!json_is_boolean(locked))
+	{
+		fprintf(stderr, "error: locked is not a boolean\n");
+		ret = 0;
+		goto finish;
+	}
+
+	size_t len = 256;
+	d->name = malloc(sizeof(char) * len);
+
+	strncpy(d->name, json_string_value(name), len);
+	d->id = (int)json_integer_value(droplet_id);
+	d->memory = (int)json_integer_value(memory);
+	d->vcpus = (int)json_integer_value(vcpus);
+	d->disk = (int)json_integer_value(disk);
+	d->locked = (int)json_boolean_value(locked);
+
+finish:
+	json_decref(root);
+	return ret;
+}

--- a/src/droplet.h
+++ b/src/droplet.h
@@ -1,0 +1,32 @@
+#ifndef _SEA_DROPLET_H
+#define _SEA_DROPLET_H
+#include <time.h>
+
+struct droplet
+{
+	int id;
+	char * name;
+	long memory;
+	int vcpus;
+	int disk;
+	int locked;
+	time_t created_at; // should this just be a char * to match the json string?
+	char * status;
+	int * backup_ids;
+	int * snapshot_ids;
+	char ** features;
+	// struct region region;
+	// struct image * image;
+	// struct size * size;
+	char * size_slug;
+	// struct network * networks;
+	// struct kernel * kernel;
+	// struct backup_window * next_backup_window;
+	char ** tags;
+	int * volume_ids;
+};
+
+struct droplet *droplet_new(void);
+void droplet_free(struct droplet *d);
+int droplet_get_by_id(struct droplet * d, int id);
+#endif // _SEA_DROPLET_H

--- a/src/sea.c
+++ b/src/sea.c
@@ -10,37 +10,63 @@
 #include "sea.h"
 #include "request.h"
 #include "account.h"
+#include "droplet.h"
 
 int main(int argc, char *argv[])
 {
-	if(argc != 2)
+	if(argc < 2)
 	{
 		fprintf(stderr, "usage: %s account\n\n", argv[0]);
 		fprintf(stderr, "Show details of the current account.\n\n");
 		return 2;
 	}
 
-	struct account *a = account_new();
-	if(a == NULL)
-	{
+	if(strncmp(argv[2], "account", ARG_SIZE) == 0) {
+		struct account *a = account_new();
+		if(a == NULL)
+		{
+			account_free(a);
+			perror("account: ");
+			return EXIT_FAILURE;
+		}
+
+		if(!account_get(a))
+			return EXIT_FAILURE;
+
+		printf("Email: %s (verified: %s)\nStatus: %s\nStatus Message: %s\nUUID: %s\nDroplet Limit: %d\nFloating IP Limit: %d\n",
+				a->email,
+				(a->email_verified) ? "true" : "false",
+				a->status,
+				a->status_message,
+				a->uuid,
+				a->droplet_limit,
+				a->floating_ip_limit);
+
 		account_free(a);
-		perror("account: ");
-		return EXIT_FAILURE;
+	} else if(strncmp(argv[1], "droplet", ARG_SIZE) == 0) {
+		struct droplet *d = droplet_new();
+		if(d == NULL)
+		{
+			droplet_free(d);
+			perror("droplet: ");
+			return EXIT_FAILURE;
+		}
+
+		int id = atoi(argv[2]);
+		if(!droplet_get_by_id(d, id))
+			return EXIT_FAILURE;
+
+		printf("ID: %d\nName: %s\nMemory: %ldM\nVCPUs: %d\nDisk: %dG\nLocked: %s\n",
+				d->id,
+				d->name,
+				d->memory,
+				d->vcpus,
+				d->disk,
+				(d->locked) ? "true" : "false"
+				);
+
+		droplet_free(d);
 	}
-
-	if(!account_get(a))
-		return EXIT_FAILURE;
-
-	printf("Email: %s (verified: %s)\nStatus: %s\nStatus Message: %s\nUUID: %s\nDroplet Limit: %d\nFloating IP Limit: %d\n",
-			a->email,
-			(a->email_verified) ? "true" : "false",
-			a->status,
-			a->status_message,
-			a->uuid,
-			a->droplet_limit,
-			a->floating_ip_limit);
-
-	account_free(a);
 
 	return EXIT_SUCCESS;
 }

--- a/src/sea.h
+++ b/src/sea.h
@@ -4,4 +4,6 @@
 #define URL_BASE "https://api.digitalocean.com/v2"
 #define URL_SIZE 256
 
+#define ARG_SIZE 256
+
 #endif /* _SEA_H */


### PR DESCRIPTION
I took a slightly different approach to the API here. I left the allocation up to the caller and only returned true/false (or the number of droplets returned, if you want to look at it that way). It doesn't seem _too_ clumsy, and cuts back on the number of allocations in the function.

Of course, it's definitely what some folks would call "cheaty face" given that I'm only dealing with the one string element and zero of the nested objects that would be returned. Expecting the caller to pre-allocate a deeply nested struct is probably a bit of a stretch, and so far I don't see a way to efficiently pre-allocate for a list of regions, for example.
